### PR TITLE
added option for transparent background

### DIFF
--- a/colors/horizon.vim
+++ b/colors/horizon.vim
@@ -224,3 +224,12 @@ if has('nvim')
 else
   let g:terminal_ansi_colors = ['#1c1e26', '#eC6a88', '#09f7a0', '#fab795', '#25b0bc', '#f09483', '#e95678', '#1c1e26', '#d5d8da', '#ec6a88', '#6bdfe6', '#fab38e', '#21bfc2', '#b877db', '#95c4ce', '#d2d4de']
 endif
+
+if exists("g:horizon_transparent_bg")
+  if g:horizon_transparent_bg==1
+    highlight Normal     ctermbg=NONE guibg=NONE
+    highlight LineNr     ctermbg=NONE guibg=NONE
+    highlight VertSplit ctermbg=NONE guibg=NONE
+    highlight EndOfBuffer ctermbg=NONE guibg=NONE
+  endif
+endif


### PR DESCRIPTION
Added option for transparency
adding `let g:horizon_transparent_bg=1` will allow the background to be transparent.