### PR TITLE
fix: broken g:terminal_ansi_colors

### DIFF
--- a/colors/horizon.vim
+++ b/colors/horizon.vim
@@ -221,7 +221,11 @@ if has('nvim')
   let g:terminal_color_13 = '#95c4ce'
   let g:terminal_color_14 = '#d2d4de'
 else
-  let g:terminal_ansi_colors = ['#1c1e26', '#eC6a88', '#09f7a0', '#fab795', '#25b0bc', '#f09483', '#e95678', '#1c1e26', '#d5d8da', '#6bdfe6', '#fab38e', '#21bfc2', '#b877db', '#95c4ce', '#d2d4de']
+  let g:terminal_ansi_colors = [
+    \ '#1c1e26', '#eC6a88', '#09f7a0', '#fab795', 
+    \ '#25b0bc', '#f09483', '#e95678', '#1c1e26', 
+    \ '#d5d8da', '#6bdfe6', '#fab38e', '#21bfc2', 
+    \ '#b877db', '#95c4ce', '#d2d4de', '#d5d8da']
 endif
 
 if exists("g:horizon_transparent_bg")


### PR DESCRIPTION
## Description 
The 16th color was missing. Making the terminal colors not work in Vim.

`:messages` showed error `E475: Invalid argument: g:terminal_ansi_colors`

The fix was to add the color for white in g:terminal_ansi_colors to the white color (`#d5d8da`) in the Horizon theme.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)
